### PR TITLE
Feature/led controller

### DIFF
--- a/orange_sensor_tools/CMakeLists.txt
+++ b/orange_sensor_tools/CMakeLists.txt
@@ -18,6 +18,12 @@ find_package(tf2_ros REQUIRED)
 find_package(pcl_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED)
+find_package(serial REQUIRED)
+
+# Add include directories
+include_directories(
+  include
+)
 
 set(dependencies
   rclcpp
@@ -46,8 +52,16 @@ install(TARGETS laserscan_multi_merger
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
+# Create cpp executable
+add_executable(led_node src/led_node.cpp)
+ament_target_dependencies(led_node rclcpp std_msgs serial)
+
+# Install cpp executable
+install(TARGETS led_node
+  DESTINATION lib/${PROJECT_NAME})
+
 # install
-install(DIRECTORY src launch config
+install(DIRECTORY config include launch src
   DESTINATION share/${PROJECT_NAME}/
 )
 

--- a/orange_sensor_tools/include/led_node.hpp
+++ b/orange_sensor_tools/include/led_node.hpp
@@ -26,6 +26,8 @@ private:
 
     std::string port_name_;
     int baud_rate_;
+    std::string nav_topic_;
+    std::string estop_topic_;
     bool nav_state_;
     bool estop_state_;
     std::string led_state_;

--- a/orange_sensor_tools/include/led_node.hpp
+++ b/orange_sensor_tools/include/led_node.hpp
@@ -1,0 +1,35 @@
+#ifndef LED_NODE_HPP
+#define LED_NODE_HPP
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/bool.hpp>
+#include <serial/serial.h>
+#include <chrono>
+
+class LedController : public rclcpp::Node
+{
+public:
+    LedController();
+    ~LedController();
+
+private:
+    void navCallback(const std_msgs::msg::Bool::SharedPtr msg);
+    void estopCallback(const std_msgs::msg::Bool::SharedPtr msg);
+    void sendSerialCommand();
+
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr nav_sub_;
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr estop_sub_;
+    //rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr led_pub_;
+    rclcpp::TimerBase::SharedPtr timer_;
+
+    serial::Serial serial_port_;
+
+    std::string port_name_;
+    int baud_rate_;
+    bool nav_state_;
+    bool estop_state_;
+    std::string led_state_;
+};
+
+#endif // LED_NODE_HPP
+

--- a/orange_sensor_tools/package.xml
+++ b/orange_sensor_tools/package.xml
@@ -21,6 +21,7 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>pointcloud_to_laserscan</depend>
   <depend>robot_localization</depend>
+  <depend>serial</depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>linefit_ground_segmentation_ros</exec_depend>
   <export>

--- a/orange_sensor_tools/src/led_node.cpp
+++ b/orange_sensor_tools/src/led_node.cpp
@@ -7,6 +7,8 @@ LedController::LedController()
 {
     port_name_ = this->declare_parameter<std::string>("serial_port", "/dev/sensors/LED");
     baud_rate_ = this->declare_parameter<int>("baud_rate", 115200);
+    nav_topic_ = this->declare_parameter<std::string>("nav_topic", "/nav_state");
+    estop_topic_ = this->declare_parameter<std::string>("estop_topic", "/estop");
 
     try
     {
@@ -22,9 +24,9 @@ LedController::LedController()
     }
 
     nav_sub_ = this->create_subscription<std_msgs::msg::Bool>(
-        "/nav_state", 10, std::bind(&LedController::navCallback, this, std::placeholders::_1));
+        nav_topic_, 10, std::bind(&LedController::navCallback, this, std::placeholders::_1));
     estop_sub_ = this->create_subscription<std_msgs::msg::Bool>(
-        "/estop_state", 10, std::bind(&LedController::estopCallback, this, std::placeholders::_1));
+        estop_topic_, 10, std::bind(&LedController::estopCallback, this, std::placeholders::_1));
     timer_ = this->create_wall_timer(200ms, std::bind(&LedController::sendSerialCommand, this));
 
     if (serial_port_.isOpen())

--- a/orange_sensor_tools/src/led_node.cpp
+++ b/orange_sensor_tools/src/led_node.cpp
@@ -1,0 +1,84 @@
+#include "led_node.hpp"
+
+using namespace std::chrono_literals;
+
+LedController::LedController()
+    : Node("LED_node"), nav_state_(false), estop_state_(false)
+{
+    port_name_ = this->declare_parameter<std::string>("serial_port", "/dev/sensors/LED");
+    baud_rate_ = this->declare_parameter<int>("baud_rate", 115200);
+
+    try
+    {
+        serial_port_.setPort(port_name_);
+        serial_port_.setBaudrate(baud_rate_);
+        serial::Timeout to = serial::Timeout::simpleTimeout(1000);
+        serial_port_.setTimeout(to);
+        serial_port_.open();
+    }
+    catch (const std::exception &e)
+    {
+        RCLCPP_ERROR(this->get_logger(), "Failed to open serial port: %s", e.what());
+    }
+
+    nav_sub_ = this->create_subscription<std_msgs::msg::Bool>(
+        "/nav_state", 10, std::bind(&LedController::navCallback, this, std::placeholders::_1));
+    estop_sub_ = this->create_subscription<std_msgs::msg::Bool>(
+        "/estop_state", 10, std::bind(&LedController::estopCallback, this, std::placeholders::_1));
+    timer_ = this->create_wall_timer(200ms, std::bind(&LedController::sendSerialCommand, this));
+
+    if (serial_port_.isOpen())
+    {
+        serial_port_.write("ON\n");
+    }
+}
+
+LedController::~LedController()
+{
+    if (serial_port_.isOpen())
+    {
+        serial_port_.write("OFF\n");
+        serial_port_.close();
+    }
+}
+
+void LedController::navCallback(const std_msgs::msg::Bool::SharedPtr msg)
+{
+    nav_state_ = msg->data;
+}
+
+void LedController::estopCallback(const std_msgs::msg::Bool::SharedPtr msg)
+{
+    estop_state_ = msg->data;
+}
+
+void LedController::sendSerialCommand()
+{
+    led_state_ = (nav_state_ && !estop_state_) ? "FLASH" : "SOLID";
+    
+    if (serial_port_.isOpen())
+    {
+        try
+        {
+            serial_port_.write(led_state_ + "\n");
+            // RCLCPP_INFO(this->get_logger(), "Sent: %s", led_state_.c_str());
+        }
+        catch (const std::exception &e)
+        {
+            RCLCPP_ERROR(this->get_logger(), "Failed to write to serial port: %s", e.what());
+        }
+    }
+    else
+    {
+        RCLCPP_ERROR(this->get_logger(), "Serial port is NOT open!");
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<LedController>());
+    rclcpp::shutdown();
+    return 0;
+}
+


### PR DESCRIPTION
## PR Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
LEDをシリアル通信で制御するノード

## Detail
ロボットの状態によってLEDの光らせ方を変えるノードを作りました。
ロボットの状態はナビゲーションの状態とE-stopの状態で決まります。

IGVC2025のルール上、ナビゲーション中はLEDを点滅させる必要があります。
そのため、/nav_stateがtrueかつ/estopがfalseならば点滅、それ以外は点灯という処理にしています。
また、電力消費を抑えるため、ノードを動かすまでLEDは点灯または点滅をしない設計にしています。

/nav_stateのトピック名は、今後全体の構成を鑑みて、適宜変更するつもりです。

## Input Topics
- /nav_state (std_msgs/msg/Bool)
ナビゲーション中かどうかを表すトピック。ナビゲーション中であればtrueとなる。
- /estop (std_msgs/msg/Bool)
E-stopを押されているかどうかを表すトピック。押されていればtrueとなる。

## Test
- [x] 実際にLEDを用いて動作を確認しました。