### PR TITLE
Feature/gps

### DIFF
--- a/orange_bringup/launch/orange_robot.launch.xml
+++ b/orange_bringup/launch/orange_robot.launch.xml
@@ -80,7 +80,7 @@
   <!-- GPSposition_publisher -->
   <!-- initial heading:housei nakaniwa=179.169287 tsukuba= 276.5 -->
   <!-- GPSheading_publisher -->
-  <node pkg="orange_bringup" exec="get_lonlat_quat_ttyUSB" output="screen">
+  <node pkg="orange_bringup" exec="get_lonlat_movingbase_quat_ttyUSB" output="screen">
     <param name="port" value="/dev/sensors/GNSS_UM982"/>
     <param name="baud" value="115200"/>
     <param name="country_id" value="0"/>

--- a/orange_bringup/orange_bringup/get_lonlat_movingbase_quat_ttyUSB.py
+++ b/orange_bringup/orange_bringup/get_lonlat_movingbase_quat_ttyUSB.py
@@ -268,7 +268,9 @@ class GPSData(Node):
         r_theta = theta * degree_to_radian
         h_x = math.cos(r_theta) * gps_x - math.sin(r_theta) * gps_y
         h_y = math.sin(r_theta) * gps_x + math.cos(r_theta) * gps_y
-        point = (-h_x, h_y)
+        point = (-h_x, -h_y)
+        #point = (-h_x, h_y)
+        #point = (h_x, -h_y)
         #point = (-h_y, h_x)
         #point = (h_y, -h_x)
 

--- a/orange_bringup/orange_bringup/get_lonlat_movingbase_quat_ttyUSB.py
+++ b/orange_bringup/orange_bringup/get_lonlat_movingbase_quat_ttyUSB.py
@@ -85,7 +85,7 @@ class GPSData(Node):
 
         while(1):
             line = serial_port.readline()
-            self.get_logger().info(f"line: {line}")
+            #self.get_logger().info(f"line: {line}")
             talker_ID_indoor = line.find(initial_letters_indoor)
             talker_ID_outdoor = line.find(initial_letters_outdoor)            
             if talker_ID_indoor != -1:
@@ -268,8 +268,9 @@ class GPSData(Node):
         r_theta = theta * degree_to_radian
         h_x = math.cos(r_theta) * gps_x - math.sin(r_theta) * gps_y
         h_y = math.sin(r_theta) * gps_x + math.cos(r_theta) * gps_y
+        point = (-h_x, h_y)
         #point = (-h_y, h_x)
-        point = (h_y, -h_x)
+        #point = (h_y, -h_x)
 
         return point
 

--- a/orange_bringup/setup.py
+++ b/orange_bringup/setup.py
@@ -37,6 +37,7 @@ setup(
             "get_lonlat_ttyACM = orange_bringup.get_lonlat_ttyACM:main",
             "get_lonlat_ttyUSB = orange_bringup.get_lonlat_ttyUSB:main",
             "get_movingbase_quat_ttyUSB = orange_bringup.get_movingbase_quat_ttyUSB:main",
+            "get_lonlat_movingbase_quat_ttyUSB = orange_bringup.get_lonlat_movingbase_quat_ttyUSB:main",
             "get_lonlat_quat_ttyUSB = orange_bringup.get_lonlat_quat_ttyUSB:main",
             "GPSodom_correction = orange_bringup.GPSodom_correction:main",
             "lonlat_to_odom = orange_bringup.lonlat_to_odom:main",

--- a/try_navigation/launch/try_navigation.launch.py
+++ b/try_navigation/launch/try_navigation.launch.py
@@ -62,9 +62,15 @@ def generate_launch_description():
             arguments=[]
         ),
         
-        ##waypoint manager
+        #waypoint manager
         
         # waypoint gps command
+        Node(package='navigation_control',
+            executable='gps_waypoint',
+            name='gps_waypoint',
+            output='screen',
+            arguments=[],
+        ),
         # $ ros2 run navigation_control gps_waypoint
         # file path /ros2_ws/src/Use_action/navigation_control/navigation_control/gps_waypoint
         
@@ -83,12 +89,12 @@ def generate_launch_description():
             arguments=[],
         ),
         #robot ctrl
-        #Node(package='try_navigation',
-        #    executable='path_follower',
-        #    name='path_follower_node',
-        #    output='screen',
-        #    arguments=[],
-        #),
+        Node(package='try_navigation',
+            executable='path_follower',
+            name='path_follower_node',
+            output='screen',
+            arguments=[],
+        ),
         
         #navigation start
         Node(package='navigation_control',

--- a/try_navigation/launch/try_navigation.launch.py
+++ b/try_navigation/launch/try_navigation.launch.py
@@ -65,12 +65,12 @@ def generate_launch_description():
         #waypoint manager
         
         # waypoint gps command
-        Node(package='navigation_control',
-            executable='gps_waypoint',
-            name='gps_waypoint',
-            output='screen',
-            arguments=[],
-        ),
+        #Node(package='navigation_control',
+        #    executable='gps_waypoint',
+        #    name='gps_waypoint',
+        #    output='screen',
+        #    arguments=[],
+        #),
         # $ ros2 run navigation_control gps_waypoint
         # file path /ros2_ws/src/Use_action/navigation_control/navigation_control/gps_waypoint
         

--- a/try_navigation/try_navigation/path_follower.py
+++ b/try_navigation/try_navigation/path_follower.py
@@ -41,9 +41,9 @@ class PathFollower(Node):
         # Subscriptionを作成。
         self.subscription = self.create_subscription(nav_msgs.Path, '/potential_astar_path', self.get_path, qos_profile) #set subscribe pcd topic name
         #self.subscription = self.create_subscription(nav_msgs.Odometry,'/odom_wheel', self.get_odom, qos_profile_sub)
-        #self.subscription = self.create_subscription(nav_msgs.Odometry,'/fusion/odom', self.get_odom, qos_profile_sub)
-        self.subscription = self.create_subscription(nav_msgs.Odometry,'/odom_ekf_match', self.get_odom, qos_profile_sub)
-        self.subscription = self.create_subscription(nav_msgs.Odometry,'/odom_ref_slam', self.get_odom_ref, qos_profile_sub)
+        self.subscription = self.create_subscription(nav_msgs.Odometry,'/fusion/odom', self.get_odom, qos_profile_sub)
+        #self.subscription = self.create_subscription(nav_msgs.Odometry,'/odom_ekf_match', self.get_odom, qos_profile_sub)
+        #self.subscription = self.create_subscription(nav_msgs.Odometry,'/odom_ref_slam', self.get_odom_ref, qos_profile_sub)
         self.subscription = self.create_subscription(sensor_msgs.PointCloud2, '/pcd_segment_obs', self.obs_steer, qos_profile)
         self.subscription  # 警告を回避するために設置されているだけです。削除しても挙動はかわりません。
         

--- a/try_navigation/try_navigation/potential_astar.py
+++ b/try_navigation/try_navigation/potential_astar.py
@@ -60,9 +60,9 @@ class PotentialAStar(Node):
         # Subscriptionを作成。CustomMsg型,'/livox/lidar'という名前のtopicをsubscribe。
         self.subscription = self.create_subscription(sensor_msgs.PointCloud2, '/pcd_segment_obs', self.potential_astar, qos_profile)
         #self.subscription = self.create_subscription(nav_msgs.Odometry,'/odom_wheel', self.get_odom, qos_profile_sub)
-        #self.subscription = self.create_subscription(nav_msgs.Odometry,'/fusion/odom', self.get_odom, qos_profile_sub)
+        self.subscription = self.create_subscription(nav_msgs.Odometry,'/fusion/odom', self.get_odom, qos_profile_sub)
         #self.subscription = self.create_subscription(nav_msgs.Odometry,'/odom_fast', self.get_odom, qos_profile_sub)
-        self.subscription = self.create_subscription(nav_msgs.Odometry,'/odom_ekf_match', self.get_odom, qos_profile_sub)
+        #self.subscription = self.create_subscription(nav_msgs.Odometry,'/odom_ekf_match', self.get_odom, qos_profile_sub)
         self.subscription = self.create_subscription(geometry_msgs.PoseArray,'/current_waypoint', self.get_waypoint, qos_profile_sub)
         self.subscription = self.create_subscription(sensor_msgs.PointCloud2, '/map_obs', self.get_map_obs, qos_profile)
         self.subscription  # 警告を回避するために設置されているだけです。削除しても挙動はかわりません。


### PR DESCRIPTION
## 概要
- UM982の/fix,/movingbase/quat,/odom/UM982を一つのプログラムで出せるように
- try_navigationパッケージのpotential_asterとpath_followerのsubするodomトピックを変更

### なぜこのタスクを行うのか
- gpsでのwaypoint作成に/fixトピックと/movingbase/quatトピックが必要なため
- 使用するodomトピックを変更する必要があったため

### やったこと
- get_lonlat_movingbase_quat.pyの作成
- potential_asterとpath_followerの編集
- その他軽微な修正

### できるようになること
- UM982の/fix,/movingbase/quat,/odom/UM982を同時に出せるように
- /odomトピックと/odom/UM982トピックのodom情報での走行

### できなくなること
- 上記以外のodomトピックの活用(/odom_ref等)

